### PR TITLE
Allow structurizr.sh to be called from any directory.

### DIFF
--- a/etc/structurizr.sh
+++ b/etc/structurizr.sh
@@ -1,1 +1,3 @@
-java -jar structurizr-cli-*.jar "$@"
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+java -jar $SCRIPT_DIR/structurizr-cli-*.jar "$@"


### PR DESCRIPTION
`structurizr.sh` will only work if the current directory contains the jar file. This change allows the directory containing the .sh and the .jar file to the PATH, and so called from any directory.