### PR TITLE
Allow structurizr.bat to be called from any directory

### DIFF
--- a/etc/structurizr.bat
+++ b/etc/structurizr.bat
@@ -1,2 +1,4 @@
 @echo off
-java -jar structurizr-cli-1.4.0.jar %*
+setlocal
+set SCRIPT_DIR=%~dp0
+java -jar "%SCRIPT_DIR%structurizr-cli-1.4.0.jar" %*


### PR DESCRIPTION
This change allows to run the `structurizr.bat` script from any relative directory.

Having the following directory structure
```
bin
    structurizr.bat
    structurizr-cli-1.4.0.jar
```

Running `bin\structurizr.bat` produced an error without this change

```
> bin\structurizr.bat
Error: Unable to access jarfile structurizr-cli-1.4.0.jar
```

With the change

```
> bin\structurizr.bat
Structurizr CLI v1.4.0
Usage: structurizr push|pull|export [options]
```

Similar change was contributed in https://github.com/structurizr/cli/pull/1