### PR TITLE
Add 'output' option to the Export command

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -1,19 +1,21 @@
 # export
 
 The ```export``` command allows you to export the views within a Structurizr workspace to a number of different formats.
-Files will be created in the same directory as the workspace, one per view that has been exported.
+Files will be created one per view that has been exported.
+If output directory is not specified, files will be created in the same directory as the workspace.
 
 ## Options
 
 - __-workspace__: The path or URL to the workspace JSON file/DSL file(s) (required)
 - __-format__: plantuml|mermaid|websequencediagrams|ilograph|json (required)
+- __-output__: Relative or absolute path to an output directory (optional)
 
 ## Examples
 
-To export all views in a JSON workspace to PlantUML format:
+To export all views in a JSON workspace to PlantUML format under folder named 'diagrams':
 
 ```
-java -jar structurizr-cli-*.jar export -workspace myworkspace.json -format plantuml
+java -jar structurizr-cli-*.jar export -workspace myworkspace.json -format plantuml -output diagrams
 ```
 
 To export all views in a JSON workspace to Mermaid format:

--- a/src/main/java/com/structurizr/cli/ExportCommand.java
+++ b/src/main/java/com/structurizr/cli/ExportCommand.java
@@ -48,6 +48,10 @@ class ExportCommand extends AbstractCommand {
         option.setRequired(true);
         options.addOption(option);
 
+        option = new Option("o", "output", true, "Path to an output directory");
+        option.setRequired(false);
+        options.addOption(option);
+
         CommandLineParser commandLineParser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();
 
@@ -55,12 +59,14 @@ class ExportCommand extends AbstractCommand {
         File workspacePath = null;
         long workspaceId = 1;
         String format = "";
+        String outputPath = null;
 
         try {
             CommandLine cmd = commandLineParser.parse(options, args);
 
             workspacePathAsString = cmd.getOptionValue("workspace");
             format = cmd.getOptionValue("format");
+            outputPath = cmd.getOptionValue("output");
 
         } catch (ParseException e) {
             System.out.println(e.getMessage());
@@ -106,8 +112,14 @@ class ExportCommand extends AbstractCommand {
         ThemeUtils.loadStylesFromThemes(workspace);
         addDefaultViewsAndStyles(workspace);
 
+        if (outputPath == null) {
+            outputPath = workspacePath.getParent();
+        }
+        File outputDir = new File(outputPath);
+        outputDir.mkdirs();
+
         if (JSON_FORMAT.equalsIgnoreCase(format)) {
-            File file = new File(workspacePath.getParent(), String.format("%s.json", prefix(workspaceId)));
+            File file = new File(outputPath, String.format("%s.json", prefix(workspaceId)));
             System.out.println(" - writing " + file.getCanonicalPath());
             WorkspaceUtils.saveWorkspaceToJson(workspace, file);
         } else if (PLANTUML_FORMAT.equalsIgnoreCase(format)) {
@@ -119,7 +131,7 @@ class ExportCommand extends AbstractCommand {
                 Collection<PlantUMLDiagram> diagrams = plantUMLWriter.toPlantUMLDiagrams(workspace);
 
                 for (PlantUMLDiagram diagram : diagrams) {
-                    File file = new File(workspacePath.getParent(), String.format("%s-%s.puml", prefix(workspaceId), diagram.getKey()));
+                    File file = new File(outputPath, String.format("%s-%s.puml", prefix(workspaceId), diagram.getKey()));
                     writeToFile(file, diagram.getDefinition());
                 }
 
@@ -127,7 +139,7 @@ class ExportCommand extends AbstractCommand {
                 for (DynamicView dynamicView : workspace.getViews().getDynamicViews()) {
                     String definition = plantUMLWriter.toString(dynamicView);
 
-                    File file = new File(workspacePath.getParent(), String.format("%s-%s-sequence.puml", prefix(workspaceId), dynamicView.getKey()));
+                    File file = new File(outputPath, String.format("%s-%s-sequence.puml", prefix(workspaceId), dynamicView.getKey()));
                     writeToFile(file, definition);
                 }
             }
@@ -140,7 +152,7 @@ class ExportCommand extends AbstractCommand {
                 Collection<MermaidDiagram> diagrams = mermaidWriter.toMermaidDiagrams(workspace);
 
                 for (MermaidDiagram diagram : diagrams) {
-                    File file = new File(workspacePath.getParent(), String.format("%s-%s.mmd", prefix(workspaceId), diagram.getKey()));
+                    File file = new File(outputPath, String.format("%s-%s.mmd", prefix(workspaceId), diagram.getKey()));
                     writeToFile(file, diagram.getDefinition());
                 }
 
@@ -148,7 +160,7 @@ class ExportCommand extends AbstractCommand {
                 for (DynamicView dynamicView : workspace.getViews().getDynamicViews()) {
                     String definition = mermaidWriter.toString(dynamicView);
 
-                    File file = new File(workspacePath.getParent(), String.format("%s-%s-sequence.mmd", prefix(workspaceId), dynamicView.getKey()));
+                    File file = new File(outputPath, String.format("%s-%s-sequence.mmd", prefix(workspaceId), dynamicView.getKey()));
                     writeToFile(file, definition);
                 }
             }
@@ -159,13 +171,13 @@ class ExportCommand extends AbstractCommand {
             } else {
                 for (DynamicView dynamicView : workspace.getViews().getDynamicViews()) {
                     String definition = webSequenceDiagramsWriter.toString(dynamicView);
-                    File file = new File(workspacePath.getParent(), String.format("%s-%s.wsd", prefix(workspaceId), dynamicView.getKey()));
+                    File file = new File(outputPath, String.format("%s-%s.wsd", prefix(workspaceId), dynamicView.getKey()));
                     writeToFile(file, definition);
                 }
             }
         } else if (ILOGRAPH_FORMAT.equalsIgnoreCase(format)) {
             String ilographDefinition = new IlographWriter().toString(workspace);
-            File file = new File(workspacePath.getParent(), String.format("%s.idl", prefix(workspaceId)));
+            File file = new File(outputPath, String.format("%s.idl", prefix(workspaceId)));
             writeToFile(file, ilographDefinition);
         } else {
             System.out.println(" - unknown output format: " + format);


### PR DESCRIPTION
Before the proposed change the `export` command creates files in the same directory as the workspace. The proposed changes add a new functionality to the `export` command - the `output` option allows to specify a relative or absolute path to the directory, where files should be created.

Example 1 - run `export` command without options - outputs help with the new option.
```
C:\github\safor\structurizr-cli\build\libs> java -jar structurizr-cli-1.4.4.jar export
Structurizr CLI v1.4.4
Missing required options: w, f
usage: export
 -f,--format <arg>      Export format:
                        plantuml|websequencediagrams|mermaid|ilograph|json
 -o,--output <arg>      Path to an output directory
 -w,--workspace <arg>   Path or URL to the workspace JSON file/DSL file(s)
```

Example 2 - run `export` command without `output` option - creates files in the same directory as the workspace.
```
C:\github\safor\structurizr-cli\build\libs> java -jar structurizr-cli-1.4.4.jar export -workspace demo.dsl -format plantuml
Structurizr CLI v1.4.4
Exporting workspace from demo.dsl
 - loading workspace from DSL
 - writing C:\github\safor\structurizr-cli\build\libs\structurizr-SystemContext.puml
 - finished
```

Example 3 - run `export` command with empty `output` option - displays help.
```
C:\github\safor\structurizr-cli\build\libs> java -jar structurizr-cli-1.4.4.jar export -workspace demo.dsl -format plantuml -output
Structurizr CLI v1.4.4
Missing argument for option: o
usage: export
 -f,--format <arg>      Export format:
                        plantuml|websequencediagrams|mermaid|ilograph|json
 -o,--output <arg>      Path to an output directory
 -w,--workspace <arg>   Path or URL to the workspace JSON file/DSL file(s)
```

Example 4 - run `export` command with relative output folder - output folder is created in the same directory as the workspace.
```
C:\github\safor\structurizr-cli\build\libs>java -jar structurizr-cli-1.4.4.jar export -workspace demo.dsl -format plantuml -output diagrams
Structurizr CLI v1.4.4
Exporting workspace from demo.dsl
 - loading workspace from DSL
 - writing C:\github\safor\structurizr-cli\build\libs\diagrams\structurizr-SystemContext.puml
 - finished
```

Example 5 - run `export` command with relative hierarchical output folder - hierarchy of output folders is created in the same directory as the workspace.
```
C:\github\safor\structurizr-cli\build\libs>java -jar structurizr-cli-1.4.4.jar export -workspace demo.dsl -format plantuml -output output\diagrams
Structurizr CLI v1.4.4
Exporting workspace from demo.dsl
 - loading workspace from DSL
 - writing C:\github\safor\structurizr-cli\build\libs\output\diagrams\structurizr-SystemContext.puml
 - finished
```

Example 6 - run `export` command from different location - output folder is created in the same directory, where application was executed.
```
C:\github\safor\structurizr-cli>java -jar build\libs\structurizr-cli-1.4.4.jar export -workspace build\libs\demo.dsl -format plantuml -output diagrams
Structurizr CLI v1.4.4
Exporting workspace from build\libs\demo.dsl
 - loading workspace from DSL
 - writing C:\github\safor\structurizr-cli\diagrams\structurizr-SystemContext.puml
 - finished
```

Example 7 - run `export` command with output directry specified as absolute path - output directory is created at the specified path.
```
C:\github\safor\structurizr-cli\build\libs>java -jar structurizr-cli-1.4.4.jar export -workspace demo.dsl -format plantuml -output c:\temp\diagrams
Structurizr CLI v1.4.4
Exporting workspace from demo.dsl
 - loading workspace from DSL
 - writing C:\temp\diagrams\structurizr-SystemContext.puml
 - finished
```