### PR TITLE
Instructions how to install on Windows

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,8 @@ The Structurizr DSL provides a way to define a software architecture model as te
 
 Download the Structurizr CLI from the [releases page](https://github.com/structurizr/cli/releases), and unzip. You will need Java (version 8+) installed, and available to use from your command line (__please note that the CLI does not work with Java versions 11.0.0-11.0.3__).
 
+Alternatively the Structurizr CLI can be installed on Windows via [scoop](https://scoop.sh/). See [Windows installation](install-windows.md).
+
 ## 2. Create a software architecture model with the DSL
 
 Create a new empty file with your favourite text editor, and copy the following text into it.

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -1,0 +1,18 @@
+# Installing Structurizr CLI on Windows
+
+Structurizr CLI is available for download on the [release page](https://github.com/structurizr/cli/releases) or it can be installed via [scoop](https://scoop.sh/).
+
+## scoop
+
+Install:
+
+```
+scoop bucket add extras
+scoop install structurizr-cli
+```
+
+Upgrade:
+
+```
+scoop update structurizr-cli
+```


### PR DESCRIPTION
On Windows it is possible to install Structurizr CLI via [scoop](https://scoop.sh/), a command-line installer for Windows.
The [structurizr-cli](https://github.com/lukesampson/scoop-extras/blob/master/bucket/structurizr-cli.json) was recently added to the [extras](https://github.com/lukesampson/scoop-extras) bucket and now can be installed from the command line as follow:

```
scoop bucket add extras
scoop install structurizr-cli
```

The installation process doesn't require the elevated priveliges and can be run under user without administator rights. The necessary files will be downloaded and made available for the execution without changes in the PATH environment variable.