### PR TITLE
dockerizing the cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+docs
+LICENSE
+*.env
+.git
+.gitignore
+Dockerfile
+*.md
+test
+site
+examples

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        registry: ${{ env.REGISTRY }}
     -
       name: Build and push
       uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          file: .docker/Dockerfile
+          file: docker/Dockerfile
           push: true
           tags: structurizr-cli:latest
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,7 @@
 name: CI to Docker hub
+env:
+  REGISTRY: leopoldodonnell
+
 on:
   push:
     branches:
@@ -7,20 +10,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: ./
-          file: docker/Dockerfile
-          push: true
-          tags: structurizr-cli:latest
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: Setup up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    -
+      name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        registry: ${{ env.REGISTRY }}
+    -
+      name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: docker/Dockerfile
+        push: true
+        tags: ${{ env.REGISTRY }}/structurizr-cli:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: CI to Docker hub
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dockerize ]
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,9 @@
 name: CI to Docker hub
 on:
   push:
-    branches: [ master, dockerize ]
+    branches:
+      - master
+      - dockerize
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: CI to Docker hub
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: .docker/Dockerfile
+          push: true
+          tags: structurizr-cli:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    steps:
     -
       name: Checkout
       uses: actions/checkout@v2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+ARG GRADLE_VERSION='6.3'
+
+FROM gradle:${GRADLE_VERSION}-jdk8 as build
+
+WORKDIR /src
+COPY . .
+USER root
+
+ARG GRADLE_BUILD_COMMAND="bootJar"
+RUN gradle test --no-daemon --console plain
+RUN gradle ${GRADLE_BUILD_COMMAND} --refresh-dependencies --no-daemon --console plain
+RUN find . -name '*.jar'
+
+FROM openjdk:8-jre-alpine as run
+
+WORKDIR /
+COPY --from=build /src/build/libs/structurizr-cli-1.6.0.jar /src/lib/structurizr-dsl-1.0.0.jar ./
+RUN mkdir -p /workdir
+WORKDIR /workdir
+
+ENTRYPOINT ["java", "-jar", "/structurizr-cli-1.6.0.jar" ]

--- a/docker/structurizr
+++ b/docker/structurizr
@@ -1,2 +1,4 @@
 #!/bin/sh -f
-docker run --rm -v ${PWD}:/workdir leopoldodonnell/structurizr-cli $@
+REGISTRY=leopoldodonnell
+TAG=latest
+docker run --rm -v ${PWD}:/workdir ${REGISTRY}/structurizr-cli:${TAG} $@

--- a/docker/structurizr
+++ b/docker/structurizr
@@ -1,0 +1,2 @@
+#!/bin/sh -f
+docker run --rm -v ${PWD}:/workdir leopoldodonnell/structurizr-cli $@

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,23 @@
+# Docker Based CLI
+
+You many not have *java* installed or properly configured to run the *structurizr cli* on your system. A *Docker* based version provides a prebuilt version of the *cli* that you can run. A *shall script* is provided to make this easy.
+
+## Installation
+
+Assuming that you have docker installed on your workstation (it can be downloaded [here](https://www.docker.com/products/docker-desktop))...
+
+On *Mac OS* or your *Linux* Copy* `docker/structurizr` to your execution path and make it executable.
+
+Once installed, `structurizr` works as if you followed the *java based instructions* with the exception that any of the files or directories that you reference must be found under your *current working directory*. If you look at the shell script, you will note that this is because your *current working directory* is mounted into the *docker container*.
+
+Feel free to adapt the `structurizr` script to your own needs; it is simple.
+
+## Building
+
+If you would like to build the image yourself
+
+```bash
+docker build --rm -t myregistry/structurizr-cli -f docker/Dockerfile .
+```
+
+Then update `structurizr` to set `REGISTRY` to `myregistry`.


### PR DESCRIPTION
Currently the structurizr cli requires users to have java correctly installed. While most people have docker nowadays, many do not have a working java environment on their workstations. This PR provides a path for those developers.
