### PR TITLE
Change "Getting started" example to fit restrictions of VS Code plugin

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,13 +61,13 @@ workspace "Getting Started" "This is a model of my software system." {
 
     model {
         user = person "User" "A user of my software system."
-        softwareSystem = softwareSystem "Software System" "My software system."
+        mySystem = softwareSystem "Software System" "My software system."
 
-        user -> softwareSystem "Uses"
+        user -> mySystem "Uses"
     }
 
     views {
-        systemContext softwareSystem "SystemContext" "An example of a System Context diagram." {
+        systemContext mySystem "SystemContext" "An example of a System Context diagram." {
             include *
             autoLayout
         }
@@ -78,7 +78,7 @@ workspace "Getting Started" "This is a model of my software system." {
                 color #ffffff
             }
             element "Person" {
-                shape person
+                shape Person
                 background #08427b
                 color #ffffff
             }

--- a/examples/getting-started/workspace.dsl
+++ b/examples/getting-started/workspace.dsl
@@ -2,13 +2,13 @@ workspace "Getting Started" "This is a model of my software system." {
 
     model {
         user = person "User" "A user of my software system."
-        softwareSystem = softwareSystem "Software System" "My software system."
+        mySystem = softwareSystem "Software System" "My software system."
 
-        user -> softwareSystem "Uses"
+        user -> mySystem "Uses"
     }
 
     views {
-        systemContext softwareSystem "SystemContext" "An example of a System Context diagram." {
+        systemContext mySystem "SystemContext" "An example of a System Context diagram." {
             include *
             autoLayout
         }
@@ -19,7 +19,7 @@ workspace "Getting Started" "This is a model of my software system." {
                 color #ffffff
             }
             element "Person" {
-                shape person
+                shape Person
                 background #08427b
                 color #ffffff
             }


### PR DESCRIPTION
The `systemticks.c4-dsl-extension` for VS Code has important features
like in-editor previews but disallows some valid DSL. This commit caters
to the lowest common denominator in the interest of smoothing adaption.