### PR TITLE
docs tweak: highlight capacity to export a workspace to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This GitHub repository contains the Structurizr CLI - a command line utility for
 - [__pull__](docs/pull.md) workspace content as JSON
 - [__lock__](docs/lock.md) a workspace
 - [__unlock__](docs/unlock.md) a workspace
-- [__export__](docs/export.md) diagrams to PlantUML, Mermaid, WebSequenceDiagrams, DOT, and Ilograph
+- [__export__](docs/export.md) diagrams to PlantUML, Mermaid, WebSequenceDiagrams, DOT, and Ilograph; or a dsl workspace to json
 - [__list__](docs/list.md) elements within a workspace
 - [__validate__](docs/validate.md) a JSON/DSL workspace definition
 


### PR DESCRIPTION
export command can export the whole workspace, as well as just diagrams.
