### PR TITLE
Support executing via symlinks #43

### DIFF
--- a/etc/structurizr.sh
+++ b/etc/structurizr.sh
@@ -2,5 +2,18 @@
 
 set -o errexit -o noclobber -o nounset -o pipefail
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Begin with BASH_SOURCE[0]
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+SCRIPT_DIR="$(cd -P "$( dirname "$SCRIPT_PATH" )" >/dev/null 2>&1 && pwd)"
+
+# Recursively resolve symlinks
+while [[ -L "$SCRIPT_PATH" ]]; do
+  # Resolve the symlink to it's target path.
+  SCRIPT_PATH=$(readlink "$SCRIPT_PATH")
+  # If the target path is relative, prepend the symlink's source dir.
+  [[ "$SCRIPT_PATH" == /* ]] || SCRIPT_PATH="$SCRIPT_DIR/$SCRIPT_PATH"
+  # Update the script dir, resolving dir symlinks in the process.
+  SCRIPT_DIR="$(cd -P "$( dirname "$SCRIPT_PATH" )" >/dev/null 2>&1 && pwd)"
+done
+
 java -cp "$SCRIPT_DIR:$SCRIPT_DIR"/lib/* com.structurizr.cli.StructurizrCliApplication "$@"

--- a/etc/structurizr.sh
+++ b/etc/structurizr.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -o errexit -o noclobber -o nounset -o pipefail
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 java -cp "$SCRIPT_DIR:$SCRIPT_DIR"/lib/* com.structurizr.cli.StructurizrCliApplication "$@"

--- a/etc/structurizr.sh
+++ b/etc/structurizr.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-java -cp $SCRIPT_DIR:$SCRIPT_DIR/lib/* com.structurizr.cli.StructurizrCliApplication "$@"
+java -cp "$SCRIPT_DIR:$SCRIPT_DIR"/lib/* com.structurizr.cli.StructurizrCliApplication "$@"


### PR DESCRIPTION
This change allows `strcuterizr.sh` to be executed via any combination of nested / recursive symlinked files and directories.

Instead of relying on the `readlink` command's `-f` (and related) option, which is not readily available on macOS, it uses a combination of:
1. `readlink` (without the `-f`) to resolve terminal (non-directory) symlinks; and
2. `cd -P` to resolve all directory symlinks.

This has been tested (on GitHub hosted runners) with various symlink combinations on macOS (10.15, 11 and 12) and Ubuntu (18.04, 20.04 and 22.04).

I also took the opportunity to:
* prevent potential accidental globbing and word splitting;
* update the shebang to allow custom Bash installations (such as when macOS users have upgraded the terribly old Bash version that ships with the OS); and
* set some best-practice error handling flags, so Bash doesn't barge on through unhandled error conditions.

Cheers.