### PR TITLE
Remove /var/lib/apt/lists/ from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17.0.5_8-jre-jammy
 WORKDIR /usr/local/structurizr-cli/
 ENV PATH /usr/local/structurizr-cli/:$PATH
 COPY build/distributions/structurizr-cli-*.zip ./
-RUN apt-get update && apt-get install -y unzip
+RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 RUN unzip /usr/local/structurizr-cli/structurizr-cli-*.zip && chmod +x structurizr.sh
 WORKDIR /usr/local/structurizr/
 


### PR DESCRIPTION
This saves around 40mb of space removing apt list files