### PR TITLE
Update version of structurizr-dsl to 1.28.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ defaultTasks 'clean', 'build', 'getDeps', 'buildZip'
 
 description = 'Structurizr CLI'
 group = 'com.structurizr'
-version = '1.28.0'
+version = '1.28.3'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
 
-	implementation 'com.structurizr:structurizr-dsl:1.28.0'
+	implementation 'com.structurizr:structurizr-dsl:1.28.3'
 	implementation 'com.structurizr:structurizr-export:1.10.1'
 	implementation 'io.github.goto1134:structurizr-d2-exporter:1.2.0'
 	implementation 'com.structurizr:structurizr-graphviz:1.7.0'


### PR DESCRIPTION
Ensures compatibility with latest structurizr-lite and structurizr-dsl components.