### PR TITLE
goto1134/structurizr-d2-exporter: Updated to v1.5.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 	implementation 'com.structurizr:structurizr-dsl:1.31.1'
 	implementation 'com.structurizr:structurizr-export:1.16.0'
-	implementation 'io.github.goto1134:structurizr-d2-exporter:1.5.1'
+	implementation 'io.github.goto1134:structurizr-d2-exporter:1.5.2'
 	implementation 'com.structurizr:structurizr-graphviz:2.2.0'
 
 	implementation 'commons-cli:commons-cli:1.5.0'


### PR DESCRIPTION
https://github.com/goto1134/structurizr-d2-exporter/releases/tag/v1.5.2